### PR TITLE
Remove Stir from stylesheet files

### DIFF
--- a/test/__tests__/remove-stilr-test.js
+++ b/test/__tests__/remove-stilr-test.js
@@ -1,0 +1,7 @@
+'use strict';
+
+describe('remove-stilr', () => {
+  it('removes stilr', () => {
+    test('remove-stilr', 'remove-stilr-test');
+  });
+});

--- a/test/remove-stilr-test.js
+++ b/test/remove-stilr-test.js
@@ -1,0 +1,11 @@
+import {StyleSheet} from '@nfl/gridiron/addons';
+import {StyleSheet, Helmet} from '@nfl/gridiron/addons';
+
+const styles = StyleSheet.create({
+  container: {
+    background: '#fff',
+    color: 'red',
+  },
+});
+
+export default styles;

--- a/test/remove-stilr-test.output.js
+++ b/test/remove-stilr-test.output.js
@@ -1,0 +1,10 @@
+import {Helmet} from '@nfl/gridiron/addons';
+
+const styles = {
+  container: {
+    background: '#fff',
+    color: 'red',
+  },
+};
+
+export default styles;

--- a/transforms/remove-stilr.js
+++ b/transforms/remove-stilr.js
@@ -1,0 +1,46 @@
+module.exports = function(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  var filterImport = (remove, imports) => {
+    return imports.filter(imp => {
+      return imp.imported.name !== remove;
+    });
+  };
+
+  root
+    .find(j.ImportDeclaration, {
+      source: {
+        type: 'Literal',
+        value: '@nfl/gridiron/addons',
+      },
+      specifiers: [{
+        imported: {
+          name: 'StyleSheet',
+        },
+      }],
+    }).forEach(p => {
+      p.value.specifiers = filterImport('StyleSheet', p.value.specifiers);
+      if (!p.value.specifiers.length) {
+        j(p).replaceWith('');
+      }
+    });
+
+  root
+    .find(j.CallExpression, {
+      type: 'CallExpression',
+      callee: {
+        object: {
+          name: 'StyleSheet',
+        },
+        property: {
+          name: 'create',
+        },
+      },
+    }).forEach(p => {
+      var styles = p.value.arguments[0];
+      j(p).replaceWith(styles);
+    });
+
+  return root.toSource();
+};


### PR DESCRIPTION
npm run test

Removes any Stylesheet imports and strips out the `StyleSheet.create` function call
