### PR TITLE
Add key attribute to interactive styles

### DIFF
--- a/jest/env.js
+++ b/jest/env.js
@@ -29,8 +29,6 @@ global.test = (transformName, testFileName, options, fakeOptions) => {
         p.join(global.baseDir, "/transforms/", transformName)
     );
 
-    const fullPath = p.join(__dirname, global.baseDir, "test", path, "../");
-
     if (fakeOptions) {
         if (fakeOptions.path) {
             path = fakeOptions.path;
@@ -38,7 +36,7 @@ global.test = (transformName, testFileName, options, fakeOptions) => {
     }
 
     expect(
-        (transform({path, fullPath, source}, {jscodeshift}, options || {}) || "").trim()
+        (transform({path, source}, {jscodeshift}, options || {}) || "").trim()
     ).toEqual(
         output.trim()
     );

--- a/jest/env.js
+++ b/jest/env.js
@@ -29,6 +29,8 @@ global.test = (transformName, testFileName, options, fakeOptions) => {
         p.join(global.baseDir, "/transforms/", transformName)
     );
 
+    const fullPath = p.join(__dirname, global.baseDir, "test", path, "../");
+
     if (fakeOptions) {
         if (fakeOptions.path) {
             path = fakeOptions.path;
@@ -36,7 +38,7 @@ global.test = (transformName, testFileName, options, fakeOptions) => {
     }
 
     expect(
-        (transform({path, source}, {jscodeshift}, options || {}) || "").trim()
+        (transform({path, fullPath, source}, {jscodeshift}, options || {}) || "").trim()
     ).toEqual(
         output.trim()
     );

--- a/test/__tests__/convert-to-radium-test.js
+++ b/test/__tests__/convert-to-radium-test.js
@@ -1,7 +1,10 @@
 "use strict";
 
+import p from "path";
+
 describe("convert-to-radium", () => {
     it("transforms correctly", () => {
-        test("convert-to-radium", "convert-to-radium-test");
+        const path = p.join(__dirname, "../");
+        test("convert-to-radium", "convert-to-radium-test", {}, {path});
     });
 });

--- a/test/convert-to-radium-test.js
+++ b/test/convert-to-radium-test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import styles from "styles/styles.js";
 
 class Article extends React.Component {
     render() {
@@ -19,6 +20,14 @@ class Article extends React.Component {
                 <span className={classNames(styles.one, styles.two)}></span>
                 <span className={styles.one} style={{width: "10px"}}></span>
                 <span className={classNames("icon", "other-icon", styles.one, styles.two)}></span>
+
+                // nodes with interactive styles (hover state, media queries)
+                // get a "key" attribute added to them
+                <span className={styles.hover}></span>
+                <span className={styles.media1}></span>
+                <span className={styles.media2}></span>
+                <span className={styles.media3}></span>
+                <span className={styles.media4}></span>
 
                 // conditional styles in a classNames call cannot be
                 // migrated programmatically, will stay unchanged

--- a/test/convert-to-radium-test.output.js
+++ b/test/convert-to-radium-test.output.js
@@ -1,5 +1,7 @@
 import React from "react";
 import radium from "react-wildcat-radium";
+import styles from "styles/styles.js";
+
 
 @radium
 class Article extends React.Component {
@@ -32,6 +34,14 @@ class Article extends React.Component {
                         ...styles.two
                     }}
                     className="icon other-icon"></span>
+
+                // nodes with interactive styles (hover state, media queries)
+                // get a "key" attribute added to them
+                <span style={styles.hover} key="hover"></span>
+                <span style={styles.media1} key="media1"></span>
+                <span style={styles.media2} key="media2"></span>
+                <span style={styles.media3} key="media3"></span>
+                <span style={styles.media4} key="media4"></span>
 
                 // conditional styles in a classNames call cannot be
                 // migrated programmatically, will stay unchanged

--- a/test/styles/styles.js
+++ b/test/styles/styles.js
@@ -1,0 +1,35 @@
+const styles = {
+    one: {
+        color: "red"
+    },
+    two: {
+        color: "green"
+    },
+    hover: {
+        [":hover"]: {
+            color: "blue"
+        }
+    },
+    media1: {
+        ["min-width: 100px"]: {
+            color: "blue"
+        }
+    },
+    media2: {
+        ["minWidth: 100px"]: {
+            color: "blue"
+        }
+    },
+    media3: {
+        ["max-width: 100px"]: {
+            color: "blue"
+        }
+    },
+    media4: {
+        ["maxWidth: 100px"]: {
+            color: "blue"
+        }
+    }
+};
+
+export default styles;

--- a/transforms/convert-to-radium.js
+++ b/transforms/convert-to-radium.js
@@ -188,7 +188,7 @@ module.exports = function (file, api) {
             }]
         }).forEach(p => {
             const styleImport = p.value.source.value;
-            const stylePath = path.join(file.fullPath, styleImport);
+            const stylePath = path.join(file.path, styleImport);
             styles = require(stylePath);
         });
 

--- a/transforms/convert-to-radium.js
+++ b/transforms/convert-to-radium.js
@@ -6,9 +6,14 @@
  * @return {string}
  */
 
+import path from "path";
+
+const mediaQueries = ["min-width", "minWidth", "max-width", "maxWidth"];
+
 module.exports = function (file, api) {
     const j = api.jscodeshift;
     const root = j(file.source);
+    let styles = null;
 
     const getAttribute = (attrName, attributes) => {
         const attrs = attributes.filter(attribute => {
@@ -21,11 +26,49 @@ module.exports = function (file, api) {
 
     const getClassAttribute = (attributes) => getAttribute("className", attributes);
     const getStyleAttribute = (attributes) => getAttribute("style", attributes);
+    const getKeyAttribute = (attributes) => getAttribute("key", attributes);
 
 
     const logError = (attr) => {
         const line = attr.loc.start.line;
         console.error(`${file.path}: Could not update styles on line ${line}`);
+    };
+
+
+    const isInteractiveStyle = (style) => {
+        if (style[":hover"]) {
+            return true;
+        }
+
+        for (const prop in style) {
+            if (style.hasOwnProperty(prop)) {
+                for (const query of mediaQueries) {
+                    if (prop.indexOf(query) > -1) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    };
+
+
+    const getInteractiveKey = (expressions) => {
+        for (const expression of expressions) {
+            if (expression.type !== "MemberExpression") {
+                continue;
+            }
+
+            if (expression.object.name === "styles") {
+                const style = expression.property.name;
+                if (isInteractiveStyle(styles[style])) {
+                    return style;
+                }
+            }
+        }
+
+        return null;
     };
 
 
@@ -77,6 +120,15 @@ module.exports = function (file, api) {
             const classAttribute = createClassAttribute(stringArgs);
             attrs.push(classAttribute);
         }
+
+        const interactiveKey = styles && getInteractiveKey(objArgs);
+        if (interactiveKey && !getKeyAttribute(attrs)) {
+            const keyAttribute = j.jsxAttribute(
+                j.jsxIdentifier("key"),
+                j.literal(interactiveKey)
+            );
+            attrs.push(keyAttribute);
+        }
     };
 
 
@@ -125,6 +177,20 @@ module.exports = function (file, api) {
         )],
         j.literal("react-wildcat-radium")
     );
+
+
+    root
+        .find(j.ImportDeclaration, {
+            specifiers: [{
+                local: {
+                    name: "styles"
+                }
+            }]
+        }).forEach(p => {
+            const styleImport = p.value.source.value;
+            const stylePath = path.join(file.fullPath, styleImport);
+            styles = require(stylePath);
+        });
 
 
     root


### PR DESCRIPTION
Radium requires a `key` attribute on any tag with hover or media query styles.

This solution adding the full path of the file to the object passed in to the transform.
