### PR TITLE
Handle spread attributes

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -15,11 +15,11 @@ jscodeshift -t transforms/convert-ad.js --extensions js $1
 echo "\n\nConverting Prefetch imports"
 jscodeshift -t transforms/convert-prefetch.js --extensions js $1
 
-echo "\n\nConverting to Radium"
-jscodeshift -t transforms/convert-to-radium.js --extensions js $1
-
 echo "\n\nRemoving Gridiron imports"
 jscodeshift -t transforms/remove-gridiron-import.js --extensions js $1
+
+echo "\n\nConverting to Radium"
+jscodeshift -t transforms/convert-to-radium.js --extensions js $1
 
 echo "\n\nRemoving Stilr stylesheets"
 jscodeshift -t transforms/remove-stilr.js --extensions js $1

--- a/transforms/convert-to-radium.js
+++ b/transforms/convert-to-radium.js
@@ -25,6 +25,10 @@ module.exports = function (file, api, options) {
 
     const getAttribute = (attrName, attributes) => {
         const attrs = attributes.filter(attribute => {
+            if (!attribute.name) {
+                return false;
+            }
+
             return attribute.name.name === attrName;
         });
 


### PR DESCRIPTION
Script was erroring on things like `<div {...props}>`

Also the radium script relied on the React.component superclass, so it has to run after that transform.
