### PR TITLE
Delete unnecessary index files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "jscodeshift": "^0.3.8",
     "nomnom": "^1.8.1",
     "resolve": "^1.1.6",
-    "shelljs": "^0.5.3"
+    "shelljs": "^0.5.3",
+    "underscore": "^1.8.3"
   },
   "bin": {
     "wildcat-codemod": "cli/wildcat-codemod.js"


### PR DESCRIPTION
If you run the migrate script on a directory, you will see output like this after all transforms have completed:

```
The following files have been marked for deletion.
run `wildcat-codemod -C` to delete them:

/Users/daniel.howard/Projects/web/src/domains/NFL/sites/Anthology/components/Header/index.js
/Users/daniel.howard/Projects/web/src/domains/NFL/sites/Anthology/components/Gallery/index.js
/Users/daniel.howard/Projects/web/src/domains/NFL/sites/Anthology/components/Article/index.js
```

Running `wildcat-codemod -C` then will delete all files in the list, and delete the list itself.
