### PR TITLE
Fix Babel interference with source project:

### DIFF
--- a/cli/wildcat-codemod.js
+++ b/cli/wildcat-codemod.js
@@ -1,12 +1,3 @@
 #! /usr/bin/env node
 
-var path = require("path");
-
-require("babel-core/register")({
-    "presets": [
-        path.resolve(__dirname, "../node_modules/babel-preset-es2015"),
-        path.resolve(__dirname, "../node_modules/babel-preset-stage-0")
-    ]
-});
-
 require("../src/codemod.js");

--- a/jest/env.js
+++ b/jest/env.js
@@ -15,13 +15,14 @@ jest.autoMockOff();
 const fs = require("fs");
 const jscodeshift = require("jscodeshift");
 const p = require("path");
+var options = require("../transforms/util/options");
 
 const read = fileName => fs.readFileSync(
     p.join(__dirname, global.baseDir, "test", fileName),
     "utf8"
 );
 
-global.test = (transformName, testFileName, options, fakeOptions) => {
+global.test = (transformName, testFileName, testOptions, fakeOptions) => {
     let path = testFileName + ".js";
     const source = read(testFileName + ".js");
     const output = read(testFileName + ".output.js");
@@ -35,11 +36,7 @@ global.test = (transformName, testFileName, options, fakeOptions) => {
         }
     }
 
-    options = options || {};
-
-    if (!options.esprima) {
-        options.esprima = require("babel-core");
-    }
+    options = Object.assign({}, options, testOptions);
 
     expect(
         (transform({path, source}, {jscodeshift}, options) || "").trim()

--- a/package.json
+++ b/package.json
@@ -9,11 +9,9 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "babel-core": "^6.1.21",
+    "babel-core": "^5.8.34",
     "babel-eslint": "^4.1.3",
     "babel-jest": "^5.3.0",
-    "babel-preset-es2015": "^6.1.18",
-    "babel-preset-stage-0": "^6.1.18",
     "eslint": "^1.7.3",
     "jest-cli": "^0.6.1",
     "jscodeshift": "^0.3.8",

--- a/src/codemod.js
+++ b/src/codemod.js
@@ -1,10 +1,10 @@
-import {cat, echo, exit, find, mv, rm} from "shelljs";
-import nomnom from "nomnom";
-import fs from "fs";
-import path from "path";
-import {exec} from "child_process";
-import _ from "underscore";
+/* global cat, echo, exec, exit, mv, rm */
+require("shelljs/global");
 
+const nomnom = require("nomnom");
+const fs = require("fs");
+const path = require("path");
+const _ = require("underscore");
 
 const transformBasePath = path.join(__dirname, "..", "transforms");
 const runFirst = [
@@ -15,7 +15,7 @@ const runLast = [
     "convert-to-radium.js"
 ];
 
-const {src, all, single, clean} = nomnom.options({
+const opts = nomnom.options({
     src: {
         position: 0,
         help: "Source directory to run the transforms against"
@@ -37,20 +37,22 @@ const {src, all, single, clean} = nomnom.options({
 }).parse();
 
 
-if (!src) {
+if (!opts.src) {
     echo("src option is required");
     exit(1);
 }
 
-const buildCMD = (filePath, file) => {
-    return `jscodeshift -t ${filePath} ${file} --extensions "jsx,js"`;
+const buildCMD = function (filePath, file) {
+    return "jscodeshift -t " + filePath + " " + file + " --extensions 'jsx,js'";
 };
 
-const markForDeletion = () => {
+const markForDeletion = function () {
     const emptyIndexFile = path.join(__dirname, "..", "empty_indexes.txt");
     const files = cat(emptyIndexFile)
                     .split("\n")
-                    .filter(f => f !== "");
+                    .filter(function (f) {
+                        return f !== "";
+                    });
     const uniqueFiles = _.uniq(files);
     const filesList = uniqueFiles.join("\n");
     filesList.to(emptyIndexFile);
@@ -60,30 +62,30 @@ const markForDeletion = () => {
     echo(filesList);
 };
 
-const renameFiles = () => {
+const renameFiles = function () {
     echo("Renaming files from .jsx to .js");
 
-    find(src)
-        .filter(file => {
+    find(opts.src)
+        .filter(function (file) {
             return file.match(/\.jsx$/);
-        }).map(file => {
+        }).map(function (file) {
             mv(file, file.replace("jsx", "js"));
         });
 };
 
-const applyTransform = (transforms) => {
+const applyTransform = function (transforms) {
     if (!transforms.length) {
         markForDeletion();
         return;
     }
 
-    const transform = transforms.shift();
-    const transformFilePath = path.join(transformBasePath, transform);
-    const cmd = buildCMD(transformFilePath, src);
+    const transformName = transforms.shift();
+    const transformFilePath = path.join(transformBasePath, transformName);
+    const cmd = buildCMD(transformFilePath, opts.src.replace(".jsx", ".js"));
 
-    echo("Applying transform", transform);
+    echo("Applying transform", transformName);
 
-    exec(cmd, (err, stdout) => {
+    exec(cmd, function (err, stdout) {
         if (err) {
             console.error(err);
         }
@@ -93,7 +95,7 @@ const applyTransform = (transforms) => {
     });
 };
 
-const deleteEmptyIndexes = () => {
+const deleteEmptyIndexes = function () {
     echo("Removing unused index files");
     const emptyIndexFile = path.join(__dirname, "..", "empty_indexes.txt");
     const emptyIndexFiles = cat(emptyIndexFile);
@@ -104,32 +106,37 @@ const deleteEmptyIndexes = () => {
 
     emptyIndexFiles
         .split("\n")
-        .filter(f => f !== "")
-        .map(f => rm(f));
+        .filter(function (f) {
+            return f !== "";
+        })
+        .map(function (f) {
+            return rm(f);
+        });
     rm(emptyIndexFile);
 };
 
-if (clean) {
+if (opts.clean) {
     deleteEmptyIndexes();
-} else if (all) {
+} else if (opts.all) {
     const transforms = fs.readdirSync(transformBasePath)
-                        .filter(fileName => fileName.match(".js$"))
-                        .filter(filename => runFirst.indexOf(filename) === -1)
-                        .filter(filename => runLast.indexOf(filename) === -1);
-    const orderedTransforms = [...runFirst, ...transforms, ...runLast];
+        .filter(function (filename) {
+            return filename.match(".js$");
+        })
+        .filter(function (filename) {
+            return runFirst.indexOf(filename) === -1;
+        })
+        .filter(function (filename) {
+            return runLast.indexOf(filename) === -1;
+        });
+
+    const orderedTransforms = [].concat(runFirst, transforms, runLast);
 
     renameFiles();
     applyTransform(orderedTransforms);
 }
 
-if (single) {
-    const transformFilePath = path.join(transformBasePath, single);
-    const cmd = buildCMD(transformFilePath, src);
-    exec(cmd, (err, stout) => {
-        if (err) {
-            console.error(err);
-        }
-
-        echo(stout);
-    });
+if (opts.single) {
+    applyTransform([
+        opts.single
+    ]);
 }

--- a/src/codemod.js
+++ b/src/codemod.js
@@ -85,12 +85,11 @@ const applyTransform = function (transforms) {
 
     echo("Applying transform", transformName);
 
-    exec(cmd, function (err, stdout) {
+    exec(cmd, function (err) {
         if (err) {
             console.error(err);
         }
 
-        echo(stdout);
         applyTransform(transforms);
     });
 };

--- a/test/convert-to-radium-test.js
+++ b/test/convert-to-radium-test.js
@@ -2,6 +2,11 @@ import React from "react";
 import classNames from "classnames";
 import styles from "styles/styles.js";
 
+import component from "component";
+import fooBar from "fooBar";
+
+@component
+@fooBar({foo: "bar"})
 class Article extends React.Component {
     render() {
         return (

--- a/test/convert-to-radium-test.output.js
+++ b/test/convert-to-radium-test.output.js
@@ -2,6 +2,11 @@ import React from "react";
 import radium from "react-wildcat-radium";
 import styles from "styles/styles.js";
 
+import component from "component";
+import fooBar from "fooBar";
+
+@component
+@fooBar({foo: "bar"})
 @radium
 class Article extends React.Component {
     render() {

--- a/transforms/convert-ad.js
+++ b/transforms/convert-ad.js
@@ -1,6 +1,7 @@
-import updateImport from "./util/update-import";
+const options = require("./util/options");
+const updateImport = require("./util/update-import");
 
-module.exports = function (file, api, options) {
+module.exports = function (file, api) {
     var j = api.jscodeshift;
     var root = j(file.source);
 

--- a/transforms/convert-helmet-import.js
+++ b/transforms/convert-helmet-import.js
@@ -1,6 +1,7 @@
-import updateImport from "./util/update-import";
+const options = require("./util/options");
+const updateImport = require("./util/update-import");
 
-module.exports = function (file, api, options) {
+module.exports = function (file, api) {
     var j = api.jscodeshift;
     var root = j(file.source);
 

--- a/transforms/convert-prefetch.js
+++ b/transforms/convert-prefetch.js
@@ -1,6 +1,7 @@
-import updateImport from "./util/update-import";
+const options = require("./util/options");
+const updateImport = require("./util/update-import");
 
-module.exports = function (file, api, options) {
+module.exports = function (file, api) {
     var j = api.jscodeshift;
     var root = j(file.source);
 

--- a/transforms/remove-gridiron-import.js
+++ b/transforms/remove-gridiron-import.js
@@ -1,29 +1,37 @@
-module.exports = function (file, api, options) {
+const options = require("./util/options");
+
+module.exports = function (file, api) {
     var j = api.jscodeshift;
     var root = j(file.source);
 
-    const ImportDeclaration = (value) => ({
-        type: "ImportDeclaration",
-        source: {
-            type: "Literal",
-            value
-        }
-    });
+    const ImportDeclaration = function (value) {
+        return {
+            type: "ImportDeclaration",
+            source: {
+                type: "Literal",
+                value: value
+            }
+        };
+    };
 
-    const importStatement = (defaultImport, source) => j.importDeclaration(
-        [j.importDefaultSpecifier(
-            j.identifier(defaultImport)
-        )],
-        j.literal(source)
-    );
+    const importStatement = function (defaultImport, source) {
+        return j.importDeclaration(
+            [j.importDefaultSpecifier(
+                j.identifier(defaultImport)
+            )],
+            j.literal(source)
+        );
+    };
 
-    const superClass = (name) => ({
-        superClass: {
-            name
-        }
-    });
+    const superClass = function (name) {
+        return {
+            superClass: {
+                name: name
+            }
+        };
+    };
 
-    const removeGridironImport = (p) => {
+    const removeGridironImport = function (p) {
         j(p).remove();
         return p;
     };
@@ -31,14 +39,15 @@ module.exports = function (file, api, options) {
     root.find(j.ImportDeclaration, ImportDeclaration("@nfl/gridiron"))
         .forEach(removeGridironImport);
 
-
     //change superclass to React.Component
     root.find(j.ClassDeclaration, superClass("GridironComponent"))
-        .forEach(p => p.node.superClass.name = "React.Component");
+        .forEach(function (p) {
+            p.node.superClass.name = "React.Component";
+        });
 
     //import react if there isn't one
     root.find(j.ClassDeclaration, superClass("React.Component"))
-        .forEach(() => {
+        .forEach(function () {
             const reactImport = root.find(j.ImportDeclaration, ImportDeclaration("react"));
             if (reactImport.paths().length === 0) {
                 root.find(j.ClassDeclaration)

--- a/transforms/remove-stilr.js
+++ b/transforms/remove-stilr.js
@@ -1,9 +1,11 @@
-module.exports = function (file, api, options) {
+const options = require("./util/options");
+
+module.exports = function (file, api) {
     const j = api.jscodeshift;
     const root = j(file.source);
 
-    var filterImport = (remove, imports) => {
-        return imports.filter(imp => {
+    var filterImport = function (remove, imports) {
+        return imports.filter(function (imp) {
             return imp.imported.name !== remove;
         });
     };
@@ -18,7 +20,7 @@ module.exports = function (file, api, options) {
                 name: "StyleSheet"
             }
         }]
-    }).forEach(p => {
+    }).forEach(function (p) {
         p.value.specifiers = filterImport("StyleSheet", p.value.specifiers);
         if (!p.value.specifiers.length) {
             j(p).replaceWith("");
@@ -35,7 +37,7 @@ module.exports = function (file, api, options) {
                 name: "create"
             }
         }
-    }).forEach(p => {
+    }).forEach(function (p) {
         var styles = p.value.arguments[0];
         j(p).replaceWith(styles);
     });

--- a/transforms/resolve-relative-imports.js
+++ b/transforms/resolve-relative-imports.js
@@ -1,8 +1,9 @@
 var fs = require("fs");
 var path = require("path");
 var resolve = require("resolve");
+const options = require("./util/options");
 
-module.exports = function (file, api, options) {
+module.exports = function (file, api) {
     const j = api.jscodeshift;
 
     // We use resolve to find the absolute paths of our imports
@@ -18,7 +19,7 @@ module.exports = function (file, api, options) {
     };
 
     const markForDeletion = (filePath) => {
-        fs.appendFile(`${__dirname}/../empty_indexes.txt`, `\n${filePath}`, function (err) {
+        fs.appendFile(__dirname + "/../empty_indexes.txt", "\n" + filePath, function (err) {
             if (err) {
                 console.error("Error:", err);
             }
@@ -68,13 +69,11 @@ module.exports = function (file, api, options) {
 
                             // Then bypass the shell index file entirely
                             // Set the import path to be the import defined in the shell index file
-                            absoluteImportPath = resolve.sync(firstStatement.node.source.value, {
-                                ...resolveOptions,
-
+                            absoluteImportPath = resolve.sync(firstStatement.node.source.value, Object.assign({}, resolveOptions, {
                                 // Trick the resolver to resolve from the current index file
                                 basedir: path.dirname(absoluteImportPath),
                                 moduleDirectory: path.dirname(absoluteImportPath)
-                            });
+                            }));
                         }
                     }
                 }
@@ -85,7 +84,7 @@ module.exports = function (file, api, options) {
                 // ...and prepend a dot/slash so jspm is happy
                 if (!relativeImportPath.startsWith(".")) {
                     // (...only if we need to)
-                    relativeImportPath = `./${relativeImportPath}`;
+                    relativeImportPath = "./" + relativeImportPath;
                 }
 
                 p.node.source.value = relativeImportPath;

--- a/transforms/util/options.js
+++ b/transforms/util/options.js
@@ -1,0 +1,3 @@
+module.exports = {
+    esprima: require("babel-core")
+};

--- a/transforms/util/update-import.js
+++ b/transforms/util/update-import.js
@@ -1,9 +1,10 @@
-const update = function (j, root, {importName, importSource, newName, newSource}) {
+const update = function (j, root, opts) {
+    // importName, importSource, newName, newSource
     const newImport = j.importDeclaration(
         [j.importDefaultSpecifier(
-            j.identifier(newName)
+            j.identifier(opts.newName)
         )],
-        j.literal(newSource)
+        j.literal(opts.newSource)
     );
 
     root
@@ -11,19 +12,19 @@ const update = function (j, root, {importName, importSource, newName, newSource}
             type: "ImportDeclaration",
             specifiers: [{
                 local: {
-                    name: importName
+                    name: opts.importName
                 }
             }],
             source: {
                 type: "Literal",
-                value: importSource
+                value: opts.importSource
             }
         })
-        .forEach(p => {
-            let {specifiers} = p.value;
-            specifiers = specifiers.filter(s => {
-                return s.imported.name !== importName;
+        .forEach(function (p) {
+            const specifiers = p.value.specifiers.filter(function (s) {
+                return s.imported.name !== opts.importName;
             });
+
             p.value.specifiers = specifiers;
 
             j(p).insertAfter(newImport);
@@ -36,4 +37,4 @@ const update = function (j, root, {importName, importSource, newName, newSource}
     return root;
 };
 
-export default update;
+module.exports = update;


### PR DESCRIPTION
- Avoid transpiling transform files to help surface errors.
- Convert ES6 to ES5 to allow CLI to run under Node 0.12.x.
- Pass options to all transforms.
- Fix single transform option.
