### PR TITLE
More decorator output fixes

### DIFF
--- a/src/codemod.js
+++ b/src/codemod.js
@@ -34,6 +34,11 @@ const opts = nomnom.options({
         flag: true,
         help: "Remove any files that have been marked for deletion",
         abbr: "C"
+    },
+    norename: {
+        flag: true,
+        help: "Don't rename .jsx files to .js",
+        abbr: "N"
     }
 }).parse();
 
@@ -88,7 +93,8 @@ const applyTransform = function (transforms) {
     const transformName = transforms.shift();
     const transformFilePath = require.resolve(path.join(transformBasePath, transformName));
 
-    const cmd = buildCMD(transformFilePath, opts.src.replace(".jsx", ".js"));
+    const renamedSrc = opts.norename ? opts.src : opts.src.replace(".jsx", ".js");
+    const cmd = buildCMD(transformFilePath, renamedSrc);
 
     echo("\nApplying transform", transformName);
 
@@ -126,7 +132,10 @@ if (opts.clean) {
 }
 
 rm(emptyIndexFile);
-renameFiles();
+
+if (!opts.norename) {
+    renameFiles();
+}
 
 if (opts.all) {
     const transforms = fs.readdirSync(transformBasePath)

--- a/transforms/convert-to-radium.js
+++ b/transforms/convert-to-radium.js
@@ -36,7 +36,6 @@ module.exports = function (file, api) {
         return attrs[0] || null;
     };
 
-
     const getClassAttribute = function (attributes) {
         return getAttribute("className", attributes);
     };
@@ -55,7 +54,6 @@ module.exports = function (file, api) {
             console.error("%s: Could not update styles on line %s", file.path, line);
         }
     };
-
 
     const isInteractiveStyle = function (style) {
         if (!style) {
@@ -79,7 +77,6 @@ module.exports = function (file, api) {
         return false;
     };
 
-
     const getInteractiveKey = function (expressions) {
         for (var expression in expressions) {
             if (expressions[expression].type !== "MemberExpression") {
@@ -96,7 +93,6 @@ module.exports = function (file, api) {
 
         return null;
     };
-
 
     const createStyleAttribute = function (styleObjects) {
         if (styleObjects.length === 0) {
@@ -119,14 +115,12 @@ module.exports = function (file, api) {
         );
     };
 
-
     const createClassAttribute = function (classes) {
         return j.jsxAttribute(
             j.jsxIdentifier("className"),
             j.literal(classes)
         );
     };
-
 
     const applyClassesAndStyles = function (attrs, allStyles) {
         const stringArgs = allStyles.filter(function (style) {
@@ -158,7 +152,6 @@ module.exports = function (file, api) {
             attrs.push(keyAttribute);
         }
     };
-
 
     const updateStyles = function (p) {
         const attrs = p.value.attributes;
@@ -199,15 +192,6 @@ module.exports = function (file, api) {
         applyClassesAndStyles(attrs, allStyles);
     };
 
-
-    const radiumImport = j.importDeclaration(
-        [j.importDefaultSpecifier(
-            j.identifier("radium")
-        )],
-        j.literal("react-wildcat-radium")
-    );
-
-
     root
         .find(j.ImportDeclaration, {
             specifiers: [{
@@ -225,18 +209,6 @@ module.exports = function (file, api) {
                 styles = require(absoluteImportPath).styles;
             }
         });
-
-
-    root
-        .find(j.ImportDeclaration, {
-            source: {
-                type: "Literal",
-                value: "react"
-            }
-        }).forEach(function (p) {
-            j(p).insertAfter(radiumImport);
-        });
-
 
     root
         .find(j.ImportDeclaration, {
@@ -257,28 +229,47 @@ module.exports = function (file, api) {
             updateStyles(p);
         });
 
-    root
-        .find(j.ClassDeclaration)
-        .forEach(function (p) {
-            const hasStyles = root
-                .find(j.JSXOpeningElement)
-                .filter(function (x) {
-                    const attrs = x.value.attributes;
-                    return getStyleAttribute(attrs) !== null;
-                });
-
-            if (hasStyles.paths().length) {
-                if (!p.node.decorators) {
-                    p.node.decorators = [];
-                }
-
-                p.node.decorators.push(
-                    j.decorator(
-                        j.identifier("radium")
-                    )
-                );
-            }
+    const hasStyles = root
+        .find(j.JSXOpeningElement)
+        .filter(function (p) {
+            const attrs = p.value.attributes;
+            return getStyleAttribute(attrs) !== null;
         });
+
+    if (hasStyles.paths().length) {
+        const radiumImport = j.importDeclaration(
+            [j.importDefaultSpecifier(
+                j.identifier("radium")
+            )],
+            j.literal("react-wildcat-radium")
+        );
+
+        root
+            .find(j.ImportDeclaration, {
+                source: {
+                    type: "Literal",
+                    value: "react"
+                }
+            }).forEach(function (p) {
+                j(p).insertAfter(radiumImport);
+            });
+
+        root
+            .find(j.ClassDeclaration)
+            .forEach(function (p) {
+                if (hasStyles.paths().length) {
+                    if (!p.node.decorators) {
+                        p.node.decorators = [];
+                    }
+
+                    p.node.decorators.push(
+                        j.decorator(
+                            j.identifier("radium")
+                        )
+                    );
+                }
+            });
+    }
 
     return toSource(root, j);
 };

--- a/transforms/remove-gridiron-import.js
+++ b/transforms/remove-gridiron-import.js
@@ -55,5 +55,5 @@ module.exports = function (file, api) {
             }
         });
 
-    return toSource(root, j);
+    return toSource(root, j, true);
 };

--- a/transforms/util/to-source.js
+++ b/transforms/util/to-source.js
@@ -1,8 +1,8 @@
 const options = require("./options");
 const _ = require("underscore");
 
-module.exports = function (root, j, workaround) {
-    if (!workaround) {
+module.exports = function (root, j, forceDecorators) {
+    if (!forceDecorators) {
         return root.toSource(options);
     }
 

--- a/transforms/util/to-source.js
+++ b/transforms/util/to-source.js
@@ -1,7 +1,11 @@
 const options = require("./options");
 const _ = require("underscore");
 
-module.exports = function (root, j) {
+module.exports = function (root, j, workaround) {
+    if (!workaround) {
+        return root.toSource(options);
+    }
+
     // workaround the missing decorator issue
     // https://github.com/facebook/jscodeshift/issues/70
     root


### PR DESCRIPTION
- Add an option to skip file renaming. Mostly useful to compare git diffs.
- Couple the @radium decorator with the radium import.
- Only use the workaround when necessary.
