### PR TITLE
RouteHandler -> React.cloneElement fix

### DIFF
--- a/test/__tests__/convert-routehandler-test.js
+++ b/test/__tests__/convert-routehandler-test.js
@@ -4,5 +4,6 @@ describe("convert-routehandler", () => {
     it("transforms correctly", () => {
         test("convert-routehandler", "convert-routehandler");
         test("convert-routehandler", "convert-routehandler-2");
+        test("convert-routehandler", "convert-routehandler-3");
     });
 });

--- a/test/convert-routehandler-3.js
+++ b/test/convert-routehandler-3.js
@@ -1,12 +1,11 @@
 import React from "react";
+import {RouteHandler} from "react-router";
 
 class Admin extends React.Component {
     static propTypes = {
         foo: React.PropTypes.shape({
             bar: React.PropTypes.string.isRequired
-        }),
-
-        children: React.PropTypes.node
+        })
     }
 
     render() {
@@ -14,10 +13,7 @@ class Admin extends React.Component {
 
         return (
             <main>
-                {React.cloneElement(this.props.children, {
-                    hasHeader: hasHeader,
-                    ...this.state
-                })}
+                <RouteHandler {...this.props} />
             </main>
         );
     }

--- a/test/convert-routehandler-3.output.js
+++ b/test/convert-routehandler-3.output.js
@@ -14,10 +14,7 @@ class Admin extends React.Component {
 
         return (
             <main>
-                {React.cloneElement(this.props.children, {
-                    hasHeader: hasHeader,
-                    ...this.state
-                })}
+                {this.props.children}
             </main>
         );
     }

--- a/test/convert-routehandler.output.js
+++ b/test/convert-routehandler.output.js
@@ -10,7 +10,6 @@ class Admin extends React.Component {
             <main>
                 {React.cloneElement(this.props.children, {
                     hasHeader: true,
-                    ...this.props,
                     ...this.state
                 })}
             </main>


### PR DESCRIPTION
- Avoid cloning props with React.cloneElement
- Return `{this.props.children}` if no attributes are found.
